### PR TITLE
Drop the solum plugin

### DIFF
--- a/excluded-plugins.txt
+++ b/excluded-plugins.txt
@@ -14,6 +14,7 @@ murano-tempest-plugin
 oswin-tempest-plugin
 sahara-tests
 senlin-tempest-plugin
+solum-tempest-plugin
 trove-tempest-plugin
 venus-tempest-plugin
 vitrage-tempest-plugin


### PR DESCRIPTION
While reviewing the snap README, I noticed another plugin that we bundle
and sees little usage (and is not a component of Charmed OpenStack or
Sunbeam). This commit removes the solum plugin for all releases until we
receive a request to reintegrate it.