### PR TITLE
Remove congress tempest plugin

### DIFF
--- a/excluded-plugins.txt
+++ b/excluded-plugins.txt
@@ -4,6 +4,7 @@
 # They will be excluded from the snap for now
 blazar-tempest-plugin
 cloudkitty-tempest-plugin
+congress-tempest-plugin
 cyborg-tempest-plugin
 ec2api-tempest-plugin
 freezer-tempest-plugin


### PR DESCRIPTION
This plugin is no longer maintained and is also not present on other OpenStack releases.

Fixes: #186