### PR TITLE
Drop maintenance for unmaintained interim releases

### DIFF
--- a/.github/workflows/update-tempest-releases.yaml
+++ b/.github/workflows/update-tempest-releases.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: [caracal, bobcat, antelope, zed, yoga, xena, wallaby, victoria, ussuri]
+        release: [caracal, bobcat, antelope, zed, yoga, ussuri]
     uses: ./.github/workflows/update-snapcraft.yaml
     with:
       openstack-release: ${{ matrix.release }}


### PR DESCRIPTION
Stop updating snap-tempest branches for unmaintained interim releases. This includes victoria, wallaby, and xena.

NOTE: zed may be technically unmaintained now, but only just, so leaving it for now.

See discussion on https://github.com/canonical/snap-tempest/pull/193#issuecomment-2261669608