### PR TITLE
Add dalmatian and epoxy releases

### DIFF
--- a/.github/workflows/update-tempest-releases.yaml
+++ b/.github/workflows/update-tempest-releases.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: [caracal, bobcat, antelope, zed, yoga, ussuri]
+        release: [epoxy, dalmatian, caracal, bobcat, antelope, zed, yoga, ussuri]
     uses: ./.github/workflows/update-snapcraft.yaml
     with:
       openstack-release: ${{ matrix.release }}


### PR DESCRIPTION
Add two more branches for newly maintained openstack releases (dalmatian and epoxy) as of today